### PR TITLE
Hack to fix OSGi-caused classloader errors

### DIFF
--- a/src/main/java/com/nlocketz/maven/plugin/MainClassSearchVisitor.java
+++ b/src/main/java/com/nlocketz/maven/plugin/MainClassSearchVisitor.java
@@ -77,7 +77,8 @@ public class MainClassSearchVisitor implements FileVisitor<Path> {
 			}
 		} catch (ClassNotFoundException | SecurityException e) {
 			throw new IOException("Couldn't reflect on class " + p.toString(), e);
-		} catch (NoSuchMethodException e) {
+			// NoClassDefFoundError ignores ClassLoader errors stemming from OSGi dependencies
+		} catch (NoSuchMethodException | NoClassDefFoundError e) {
 			// Nothing wrong here, just didn't find a main method
 		}
 		return FileVisitResult.CONTINUE;


### PR DESCRIPTION
This fixes situations in which classes from OSGi bundles which are optional dependencies are referenced in visited class files. For example, `org.apache.log4j:1.2.17` references `javax.jms.JMSException`, but its [POM file][l4j-pom] lists `java.jms.*` as an optionally loaded bundle under its Apache Felix configuration. Since this jar is not on the project's classpath (despite not needing to be), the classloader for `java-entry-maven-plugin` throws a `NoClassDefFoundError` due to the missing class referenced in log4j's compiled `.class` file.

This PR is more of a hack than a fix, since we just eat the linkage error in these situations (which is fine, since this is mainly for our use and we don't care about these classes...if it turns out that we want such a class included, then this fix will need to be revisited).

[l4j-pom]: https://repo1.maven.org/maven2/log4j/log4j/1.2.17/log4j-1.2.17.pom